### PR TITLE
Fix TypeError for certain breadcrumb components

### DIFF
--- a/src/__snapshots__/index.test.jsx.snap
+++ b/src/__snapshots__/index.test.jsx.snap
@@ -273,9 +273,16 @@ exports[`react-router-breadcrumbs-hoc Valid routes Should render breadcrumb comp
               "path": "/1",
             },
             Object {
-              "breadcrumb": <span>
-                TWO
-              </span>,
+              "breadcrumb": <breadcrumb
+                match={
+                  Object {
+                    "isExact": true,
+                    "params": Object {},
+                    "path": "/1/2",
+                    "url": "/1/2",
+                  }
+                }
+              />,
               "match": Object {
                 "isExact": true,
                 "params": Object {},
@@ -285,9 +292,18 @@ exports[`react-router-breadcrumbs-hoc Valid routes Should render breadcrumb comp
               "path": "/1/2",
             },
             Object {
-              "breadcrumb": <span>
-                3
-              </span>,
+              "breadcrumb": <BreadcrumbMatchTest
+                match={
+                  Object {
+                    "isExact": true,
+                    "params": Object {
+                      "number": "3",
+                    },
+                    "path": "/1/2/:number",
+                    "url": "/1/2/3",
+                  }
+                }
+              />,
               "match": Object {
                 "isExact": true,
                 "params": Object {
@@ -299,13 +315,18 @@ exports[`react-router-breadcrumbs-hoc Valid routes Should render breadcrumb comp
               "path": "/1/2/:number",
             },
             Object {
-              "breadcrumb": <NavLink
-                activeClassName="active"
-                ariaCurrent="true"
-                to="/1/2/3/4"
-              >
-                Link
-              </NavLink>,
+              "breadcrumb": <BreadcrumbNavLinkTest
+                match={
+                  Object {
+                    "isExact": true,
+                    "params": Object {
+                      "number": "3",
+                    },
+                    "path": "/1/2/:number/4",
+                    "url": "/1/2/3/4",
+                  }
+                }
+              />,
               "match": Object {
                 "isExact": true,
                 "params": Object {
@@ -369,47 +390,84 @@ exports[`react-router-breadcrumbs-hoc Valid routes Should render breadcrumb comp
           <span
             key="/1/22"
           >
-            <span>
-              TWO
-            </span>
+            <breadcrumb
+              match={
+                Object {
+                  "isExact": true,
+                  "params": Object {},
+                  "path": "/1/2",
+                  "url": "/1/2",
+                }
+              }
+            >
+              <span>
+                TWO
+              </span>
+            </breadcrumb>
           </span>
           <span
             key="/1/2/:number3"
           >
-            <span>
-              3
-            </span>
+            <BreadcrumbMatchTest
+              match={
+                Object {
+                  "isExact": true,
+                  "params": Object {
+                    "number": "3",
+                  },
+                  "path": "/1/2/:number",
+                  "url": "/1/2/3",
+                }
+              }
+            >
+              <span>
+                3
+              </span>
+            </BreadcrumbMatchTest>
           </span>
           <span
             key="/1/2/:number/44"
           >
-            <NavLink
-              activeClassName="active"
-              ariaCurrent="true"
-              to="/1/2/3/4"
+            <BreadcrumbNavLinkTest
+              match={
+                Object {
+                  "isExact": true,
+                  "params": Object {
+                    "number": "3",
+                  },
+                  "path": "/1/2/:number/4",
+                  "url": "/1/2/3/4",
+                }
+              }
             >
-              <Route
-                path="/1/2/3/4"
+              <NavLink
+                activeClassName="active"
+                ariaCurrent="true"
+                to="/1/2/3/4"
               >
-                <Link
-                  aria-current="true"
-                  className="active"
-                  replace={false}
-                  style={Object {}}
-                  to="/1/2/3/4"
+                <Route
+                  path="/1/2/3/4"
                 >
-                  <a
+                  <Link
                     aria-current="true"
                     className="active"
-                    href="/1/2/3/4"
-                    onClick={[Function]}
+                    replace={false}
                     style={Object {}}
+                    to="/1/2/3/4"
                   >
-                    Link
-                  </a>
-                </Link>
-              </Route>
-            </NavLink>
+                    <a
+                      aria-current="true"
+                      className="active"
+                      href="/1/2/3/4"
+                      onClick={[Function]}
+                      style={Object {}}
+                    >
+                      Link
+                    </a>
+                  </Link>
+                </Route>
+              </NavLink>
+            </BreadcrumbNavLinkTest>
           </span>
         </div>
       </Breadcrumbs>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -6,7 +6,9 @@ const DEFAULT_MATCH_OPTIONS = { exact: true };
 // if user is passing a function (component) as a breadcrumb, make sure we
 // pass the match object into it. Else just return the string.
 const renderer = ({ breadcrumb, match }) => {
-  if (typeof breadcrumb === 'function') { return breadcrumb({ match }); }
+  if (typeof breadcrumb === 'function') {
+    return createElement(breadcrumb, { match });
+  }
   return breadcrumb;
 };
 

--- a/src/index.test.jsx
+++ b/src/index.test.jsx
@@ -41,12 +41,9 @@ components.BreadcrumbNavLinkTest.propTypes = {
   match: PropTypes.shape(matchShape).isRequired,
 };
 
-// randomize routes in array to make sure order doesn't matter
-const shuffle = arr => arr.sort(() => Math.random() - 0.5);
-
 describe('react-router-breadcrumbs-hoc', () => {
   describe('Valid routes', () => {
-    const routes = shuffle([
+    const routes = [
       // test home route
       { path: '/', breadcrumb: 'Home' },
       // test breadcrumb passed as string
@@ -59,7 +56,7 @@ describe('react-router-breadcrumbs-hoc', () => {
       { path: '/1/2/:number/4', breadcrumb: components.BreadcrumbNavLinkTest },
       // test a no-match route
       { path: '/no-match', breadcrumb: 'no match' },
-    ]);
+    ];
     const routerProps = {
       context: {},
       location: { pathname: '/1/2/3/4' },
@@ -75,9 +72,9 @@ describe('react-router-breadcrumbs-hoc', () => {
   });
 
   describe('No matching routes', () => {
-    const routes = shuffle([
+    const routes = [
       { path: '/1', breadcrumb: '1' },
-    ]);
+    ];
     const routerProps = {
       context: {},
       location: { pathname: 'nope' },
@@ -92,14 +89,14 @@ describe('react-router-breadcrumbs-hoc', () => {
   });
 
   describe('Custom match options', () => {
-    const routes = shuffle([
+    const routes = [
       {
         path: '/1',
         breadcrumb: '1',
         // not recommended, but supported
         matchOptions: { exact: false, strict: true },
       },
-    ]);
+    ];
     const routerProps = {
       context: {},
       location: { pathname: '/1/2' },


### PR DESCRIPTION
For certain breadcrumb components, the render could return a TypeError. Switching over to createElement fixes the issue.