### PR TITLE
Add typings for matchOptions (#42)

### DIFF
--- a/types/react-router-breadcrumbs-hoc/index.d.ts
+++ b/types/react-router-breadcrumbs-hoc/index.d.ts
@@ -16,6 +16,11 @@ export interface Options {
 export interface BreadcrumbsRoute {
   path: string;
   breadcrumb: React.ReactNode | string;
+  matchOptions?: {
+    exact?: boolean;
+    sensitive?: boolean;
+    strict?: boolean;
+  }
 }
 
 export interface BreadcrumbsProps<T = {}> {

--- a/types/react-router-breadcrumbs-hoc/react-router-breadcrumbs-hoc-tests.tsx
+++ b/types/react-router-breadcrumbs-hoc/react-router-breadcrumbs-hoc-tests.tsx
@@ -18,7 +18,16 @@ const UserBreadcrumb = ({ match }: UserBreadcrumbProps) => (
 
 const routes: BreadcrumbsRoute[] = [
   { path: "/users/:userId", breadcrumb: UserBreadcrumb },
-  { path: "/example", breadcrumb: "Custom Example" }
+  { path: "/example", breadcrumb: "Custom Example" },
+  {
+    path: "/example/config",
+    breadcrumb: "Custom Example with Config",
+    matchOptions: {
+      exact: true,
+      sensitive: false,
+      strict: false,
+    }
+  }
 ];
 
 const Breadcrumbs = ({ breadcrumbs }: InjectedProps) => (


### PR DESCRIPTION
Add typings for the options supported by `matchPath` [[1]] (other than `path`
itself, which is covered already). The object and all options are
optional.

[1]: https://github.com/ReactTraining/react-router/blob/d28d46dce08a5756a085f7e5eebb5169ea59e40b/packages/react-router/modules/matchPath.js#L31