### PR TITLE
Allows to pass props from routes to breadcrumbs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,7 @@
   "parser": "babel-eslint",
   "env": { "jasmine": true },
   "rules": {
+    "object-curly-newline": 0,
     "react/destructuring-assignment": 0,
     "react/jsx-one-expression-per-line": 0
   }

--- a/src/index.js
+++ b/src/index.js
@@ -29,8 +29,8 @@ const NO_BREADCRUMB = 'NO_BREADCRUMB';
  * Renders and returns the breadcrumb complete
  * with `match`, `location`, and `key` props.
  */
-const render = ({ breadcrumb, match, location }) => {
-  const componentProps = { match, location, key: match.url };
+const render = ({ breadcrumb, match, location, ...rest }) => {
+  const componentProps = { match, location, key: match.url, ...rest };
   if (typeof breadcrumb === 'function') {
     return createElement(breadcrumb, componentProps);
   }
@@ -73,7 +73,7 @@ const getBreadcrumb = ({
   }
 
   // Loop through the route array and see if the user has provided a custom breadcrumb.
-  routes.some(({ breadcrumb: userProvidedBreadcrumb, matchOptions, path }) => {
+  routes.some(({ breadcrumb: userProvidedBreadcrumb, matchOptions, path, ...rest }) => {
     if (!path) {
       throw new Error('withBreadcrumbs: `path` must be provided in every route object');
     }
@@ -104,6 +104,7 @@ const getBreadcrumb = ({
         breadcrumb: userProvidedBreadcrumb || humanizeString(currentSection),
         match,
         location,
+        ...rest,
       });
       return true;
     }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -254,6 +254,17 @@ describe('react-router-breadcrumbs-hoc', () => {
     });
   });
 
+  describe('When using additional props inside routes', () => {
+    it('Should forward additional from props from routes to generated breadcrumbs', () => {
+      const routes = [{ path: '/one', breadcrumb: 'One', foo: 'One Foo', bar: 'One Bar' }, { path: '/one/two', foo: 'Two Foo' }];
+      const breadcrumbs = getMethod()({ routes, location: { pathname: '/one/two' } });
+      expect(breadcrumbs[1].props).toHaveProperty('foo', 'One Foo');
+      expect(breadcrumbs[1].props).toHaveProperty('bar', 'One Bar');
+      expect(breadcrumbs[2].props).toHaveProperty('foo', 'Two Foo');
+      expect(breadcrumbs[2].props).not.toHaveProperty('bar');
+    });
+  });
+
   describe('Options', () => {
     describe('excludePaths', () => {
       it('Should not return breadcrumbs for specified paths', () => {


### PR DESCRIPTION
Fixes #48.

@icd2k3 simpler than I thought.