### PR TITLE
Add basic support for 404 route breadcrumbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,15 @@ To fix the issue above, just adjust the order of your routes:
 // example.com/users/123 = 'id-breadcrumb'
 ```
 
+## routeNotFoundBreadcrumb (404)
+
+You can optionally provide a breadcrumb for 404 routes with the `routeNotFoundBreadcrumb` option.
+
+```js
+withBreadcrumbs([{ path: '/users', breadcrumb: 'Users' }], { routeNotFoundBreadcrumb: '404' })
+// '/users/no-route-set' === 'Users / 404'
+```
+
 ## API
 
 ```js
@@ -183,8 +192,9 @@ Route = {
 }
 
 Options = {
-  excludePaths: Array       // disable default breadcrumb generation for specific paths
-  disableDefaults: Boolean  // disable all default breadcrumb generation
+  excludePaths: Array                       // disable default breadcrumb generation for specific paths
+  disableDefaults: Boolean                  // disable all default breadcrumb generation
+  routeNotFoundBreadcrumb: String|Function  // optionally provide a breadcrumb for 404 routes
 }
 
 // if routes are not passed, default breadcrumbs will be returned

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router-breadcrumbs-hoc",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Just a tiny, flexible, higher order component for rendering breadcrumbs with react-router 4.x",
   "repository": "icd2k3/react-router-breadcrumbs-hoc",
   "keywords": [

--- a/src/index.js
+++ b/src/index.js
@@ -60,8 +60,10 @@ const getBreadcrumb = ({
   currentSection,
   disableDefaults,
   excludePaths,
+  isLastSection,
   location,
   pathSection,
+  routeNotFoundBreadcrumb,
   routes,
 }) => {
   let breadcrumb;
@@ -85,6 +87,17 @@ const getBreadcrumb = ({
     // see: `if (breadcrumb !== NO_BREADCRUMB)` below.
     if ((match && userProvidedBreadcrumb === null) || (!match && matchOptions)) {
       breadcrumb = NO_BREADCRUMB;
+      return true;
+    }
+
+    // If the routeNotFoundBreadcrumb option is set, and this is the last path section
+    // then return that breadcrumb
+    if (!match && isLastSection && routeNotFoundBreadcrumb) {
+      breadcrumb = render({
+        breadcrumb: routeNotFoundBreadcrumb,
+        match: { url: '404' },
+        ...rest,
+      });
       return true;
     }
 
@@ -138,24 +151,29 @@ export const getBreadcrumbs = ({ routes, location, options = {} }) => {
   const matches = [];
   const { pathname } = location;
 
-  pathname
+  const splitPathname = pathname
     .split('?')[0]
     // Remove trailing slash "/" from pathname.
     .replace(/\/$/, '')
     // Split pathname into sections.
-    .split('/')
+    .split('/');
+
+  splitPathname
     // Reduce over the sections and call `getBreadcrumb()` for each section.
-    .reduce((previousSection, currentSection) => {
+    .reduce((previousSection, currentSection, index) => {
       // Combine the last route section with the currentSection.
       // For example, `pathname = /1/2/3` results in match checks for
       // `/1`, `/1/2`, `/1/2/3`.
       const pathSection = !currentSection ? '/' : `${previousSection}/${currentSection}`;
+
+      const isLastSection = index >= splitPathname.length - 1;
 
       const breadcrumb = getBreadcrumb({
         currentSection,
         location,
         pathSection,
         routes,
+        isLastSection,
         ...options,
       });
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -277,8 +277,21 @@ describe('react-router-breadcrumbs-hoc', () => {
       it('Should disable all default breadcrumb generation', () => {
         const routes = [{ path: '/one', breadcrumb: 'One' }, { path: '/one/two' }];
         const { breadcrumbs } = render({ pathname: '/one/two', routes, options: { disableDefaults: true } });
-
         expect(breadcrumbs).toBe('One');
+      });
+    });
+
+    describe('routeNotFoundBreadcrumb', () => {
+      it('Should render a breadcrumb when there is no route match', () => {
+        const routes = [{ path: '/one', breadcrumb: 'One' }];
+        const { breadcrumbs } = render({ pathname: '/one/two', routes, options: { routeNotFoundBreadcrumb: '404' } });
+        expect(breadcrumbs).toBe('Home / One / 404');
+      });
+
+      it('Should also work when disableDefaults is set', () => {
+        const routes = [{ path: '/one', breadcrumb: 'One' }];
+        const { breadcrumbs } = render({ pathname: '/one/two', routes, options: { routeNotFoundBreadcrumb: '404', disableDefaults: true } });
+        expect(breadcrumbs).toBe('One / 404');
       });
     });
   });


### PR DESCRIPTION
Adds an optional `routeNotFoundBreadcrumb` option to be able to render a breadcrumb for 404 routes.

Fixes https://github.com/icd2k3/react-router-breadcrumbs-hoc/issues/50