### PR TITLE
Fix null as routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router-breadcrumbs-hoc",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "small, flexible, higher order component for rendering breadcrumbs with react-router 4.x",
   "repository": "icd2k3/react-router-breadcrumbs-hoc",
   "main": "dist/cjs/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -192,7 +192,7 @@ export const getBreadcrumbs = ({ routes, location, options = {} }) => {
  * Takes a route array and recursively flattens it IF there are
  * nested routes in the config.
 */
-const flattenRoutes = routes => routes.reduce((arr, route) => {
+const flattenRoutes = routes => (routes || []).reduce((arr, route) => {
   if (route.routes) {
     return arr.concat([route, ...flattenRoutes(route.routes)]);
   }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -311,6 +311,13 @@ describe('react-router-breadcrumbs-hoc', () => {
       });
     });
 
+    describe('options without routes array', () => {
+      it('Should be able to set options without defining a routes array', () => {
+        const { breadcrumbs } = render({ pathname: '/one/two', routes: null, options: { excludePaths: ['/', '/one'] } });
+        expect(breadcrumbs).toBe('Two');
+      });
+    });
+
     describe('disableDefaults', () => {
       it('Should disable all default breadcrumb generation', () => {
         const routes = [{ path: '/one', breadcrumb: 'One' }, { path: '/one/two' }];


### PR DESCRIPTION
Fixes a small issue to allow for `null` to be passed as a routes array. This is for the use case of someone using default breadcumbs, but wants to use the `options` object as well.