### PR TITLE
Fix typedef oversight

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router-breadcrumbs-hoc",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "small, flexible, higher order component for rendering breadcrumbs with react-router 4.x",
   "repository": "icd2k3/react-router-breadcrumbs-hoc",
   "main": "dist/cjs/index.js",

--- a/types/react-router-breadcrumbs-hoc/index.d.ts
+++ b/types/react-router-breadcrumbs-hoc/index.d.ts
@@ -38,6 +38,6 @@ export type withRouter<P extends InjectedProps<any>> = (component: React.Compone
 >;
 
 export default function withBreadcrumbs<P>(
-  routes: BreadcrumbsRoute[],
+  routes?: BreadcrumbsRoute[],
   options?: Options
 ): withRouter<InjectedProps<P>>;


### PR DESCRIPTION
This PR fixes a type definition mistake outlined in https://github.com/icd2k3/react-router-breadcrumbs-hoc/issues/81